### PR TITLE
send mail to configured user, not user running needrestart

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Defaults:
     needrestart_action: l
     
     # Email which will be notified
-    needrestart_mail_address: $NR_USERNAME
+    needrestart_mail_address: root
     
     # Services which should be ignored
     needrestart_ignorelist: [] 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ needrestart_notifyd_disable_notify_send: 1
 needrestart_action: l
 
 # Email which will be notified
-needrestart_mail_address: $NR_USERNAME
+needrestart_mail_address: root
 
 # Services which should be ignored
 needrestart_ignorelist: []

--- a/templates/600-mail.j2
+++ b/templates/600-mail.j2
@@ -4,6 +4,7 @@
 #
 # Authors:
 #   Thomas Liske <thomas@fiasko-nw.net>
+#   modifications by systemli and mdik
 #
 # Copyright Holder:
 #   2013 - 2017 (C) Thomas Liske [http://fiasko-nw.net/~thomas/]

--- a/templates/600-mail.j2
+++ b/templates/600-mail.j2
@@ -28,14 +28,7 @@ if [ "$NR_NOTIFYD_DISABLE_MAIL" = '1' ]; then
     exit 1
 fi
 
-# Skip system users
-NR_USERID=`id -u "$NR_USERNAME"`
-if [ "0$NR_USERID" -gt 0 -a "0$NR_USERID" -lt 1000 ]; then
-    echo "[$0] do not notify system-user $NR_USERNAME via mail" 1>&2
-    exit 1
-fi
-
-echo "[$0] notify user $NR_USERNAME on $NR_SESSION via mail" 1>&2
+echo "[$0] notify {{ needrestart_mail_address }} on $NR_SESSION via mail" 1>&2
 
 {
     _NR_FQDN=$(hostname -f)


### PR DESCRIPTION
Hi,

upstream 600-mail only sends mail if the user id of the user running needrestart is either 0 or larger than 1000, which means there might be cases where no mail is sent even, though `needrestart_notifyd_disable_email` and `needrestart_mail_address` are configured to send mail to a specific user. This might lead to unexpected behaviour (from the ansible user's point of view).

This pull requests solves this, although, I think it would be better to introduce a correpsonding configuration variable upstream?


Sincerely,

Malte