### PR TITLE
needrestart: check_mk checks (local or mrpe)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,8 @@ needrestart_mail_address: $NR_USERNAME
 
 # Services which should be ignored
 needrestart_ignorelist: []
+
+# needrestart check_mk related
+needrestart_checkmk_localcheckdir: /usr/lib/check_mk_agent/local
+needrestart_checkmk_localcheck: False
+needrestart_checkmk_mrpe: False

--- a/files/check_needrestart
+++ b/files/check_needrestart
@@ -1,0 +1,23 @@
+#! /bin/bash
+#
+# wrapper script to use the nagios plugin mode of needrestart
+# as a check_mk local check (see: https://mathias-kettner.de/checkmk_localchecks.html)
+#
+
+declare -r OFILE=/tmp/.needrestart.out
+
+sudo -n -- /usr/sbin/needrestart -p > $OFILE 2>/dev/null
+
+declare -ri STATUSERR=$?
+
+STATUSERRTXT="OK"
+if [ $STATUSERR -eq 1 ]; then
+	STATUSERRTXT="WARNING"
+elif [ $STATUSERR -gt 1 ]; then
+	STATUSERRTXT="CRITICAL"
+fi
+STATUSDESCR=$(echo $(cat $OFILE | sed '1d'))
+STATUSPERF=$(cat $OFILE | sed '1!d; s/.*| *//g;s/ /|/g')
+
+echo "$STATUSERR NEEDRESTART $STATUSPERF $STATUSERRTXT - $STATUSDESCR"
+exit $STATUSERR

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: un-register check_needrestart as a mrpe check
   lineinfile:
-    path: /etc/check_mk/mrpe.cfg
+    dest: /etc/check_mk/mrpe.cfg
     regexp: '^NEEDRESTART\s+sudo -n -- /usr/sbin/needrestart -p'
     state: absent
   when: not (needrestart_checkmk_mrpe | default(False))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,3 +34,26 @@
     owner: root
     group: root
     mode: 0755
+
+- name: install check_needrestart as a check_mk local check
+  copy:
+    src: check_needrestart
+    dest: "{{ needrestart_checkmk_localcheckdir }}/check_needrestart"
+  when: needrestart_checkmk_localcheck | default(False)
+
+- name: register check_needrestart as a mrpe check
+  lineinfile:
+    dest: /etc/check_mk/mrpe.cfg
+    line: "NEEDRESTART\tsudo -n -- /usr/sbin/needrestart -p"
+    state: present
+    create: yes
+    mode: 0644
+  when: needrestart_checkmk_mrpe | default(False)
+
+- name: un-register check_needrestart as a mrpe check
+  lineinfile:
+    path: /etc/check_mk/mrpe.cfg
+    regexp: '^NEEDRESTART\s+sudo -n -- /usr/sbin/needrestart -p'
+    state: absent
+  when: not (needrestart_checkmk_mrpe | default(False))
+


### PR DESCRIPTION
improve nagios / icinga / check_mk integration:

register needrestart check as a mrpe check
register needrestar as a check_mk local check