### PR TITLE
ensure the required directories / files for the checkmk stuff are present

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,12 +35,30 @@
     group: root
     mode: 0755
 
+- name: ensure the directory for check_mk local check exists
+  file:
+    path: "{{ needrestart_checkmk_localcheckdir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when: needrestart_checkmk_localcheck | default(False)
+
 - name: install check_needrestart as a check_mk local check
   copy:
     src: check_needrestart
     dest: "{{ needrestart_checkmk_localcheckdir }}/check_needrestart"
     mode: 0755
   when: needrestart_checkmk_localcheck | default(False)
+
+- name: ensure check_mk mrpe file exists
+  file:
+    path: /etc/check_mk/mrpe.cfg
+    state: file
+    owner: root
+    group: root
+    mode: 0644
+  when: needrestart_checkmk_mrpe | default(False)
 
 - name: register check_needrestart as a mrpe check
   lineinfile:


### PR DESCRIPTION
ensure the required directories / files for the checkmk stuff are present, if the checkmk tasks are enabled