### PR TITLE
Add option for custom restart scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Defaults:
     #   - /opt/.*/java
     needrestart_blacklist_bin: []
 
+    # Custom needrestart scripts
+    # Example:
+    # needrestart_restartd:
+    #   - name: unbound
+    #     script: "systemctl restart unbound.service"
+    needrestart_restartd: []
+
 Download
 --------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,10 @@ needrestart_checkmk_mrpe: False
 
 # Override old needrestart.conf
 needrestart_update_needrestart_conf: False
+
+# Register custom restart scripts
+# Example:
+# needrestart_restartd:
+#   - name: unbound
+#     script: "systemctl restart unbound.service"
+needrestart_restartd: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,3 +98,12 @@
     regexp: '^NEEDRESTART\s+sudo -n -- /usr/sbin/needrestart -p'
     state: absent
   when: not (needrestart_checkmk_mrpe | default(False))
+
+- name: Register custom restart scripts
+  ansible.builtin.copy:
+    content: "{{ item.script }}"
+    dest: "/etc/needrestart/restart.d/{{ item.service_name }}.service"
+    owner: root
+    group: root
+    mode: "0755"
+  loop: "{{ needrestart_restartd }}"


### PR DESCRIPTION
As the title says: It would be great to have the possibility to define your own restart scripts.
There are quite a few possible uses for this.

And this form of implementation gives you maximum leeway, as you can either write them directly into the variable definition or read them from a file using lookup.

Examples:
```yaml
needrestart_restartd:
  - name: unbound
    script: "echo "restart unbound!" && systemctl restart unbound.service"
```

```yaml
needrestart_restartd:
  - name: unbound
    script: "{{ lookup('template', 'files/custom-restart', errors='strict') }}"
```