### PR TITLE
add blacklist_interp

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,12 @@ needrestart_blacklist_rc: []
 #   - /opt/.*/java
 needrestart_blacklist_bin: []
 
+# Blacklist files as regex
+# Example:
+# needrestart_blacklist_interp:
+#   - /nexus-data/.*/bundle.jar
+needrestart_blacklist_interp: []
+
 # needrestart check_mk related
 needrestart_checkmk_localcheckdir: /usr/lib/check_mk_agent/local
 needrestart_checkmk_localcheck: False

--- a/templates/needrestart_blacklist.conf.j2
+++ b/templates/needrestart_blacklist.conf.j2
@@ -18,3 +18,10 @@ push ( @{$nrconf{blacklist_rc}}, (
     )
 );
 
+#Blacklist script files
+push ( @{$nrconf{blacklist_interp}}, (
+{% for blacklistinterp in needrestart_blacklist_interp %}
+    qr(^{{ blacklistinterp }}$),
+{% endfor %}
+    )
+);


### PR DESCRIPTION
Added https://github.com/liske/needrestart/blob/master/ex/needrestart.conf#L146-L153

I also thought about adding [blacklist_mappings](https://github.com/liske/needrestart/blob/master/ex/needrestart.conf#L155-L178), but I'm not sure if this would require more complex template options.
A valid option would be for example: `qr#^(/var)?/tmp/#,`